### PR TITLE
chore(docs): enable worker observability logs and traces

### DIFF
--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -6,5 +6,21 @@
   "assets": {
     "binding": "ASSETS",
     "directory": ".svelte-kit/cloudflare"
+  },
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "redact_query_string": false,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1
+    }
   }
 }


### PR DESCRIPTION
Syncs `docs/wrangler.jsonc` with the observability settings already configured in the Cloudflare dashboard, so they persist across deployments.

- `logs`: enabled, persisted, with invocation logs
- `traces`: enabled, persisted